### PR TITLE
Workaround to get invoke working again

### DIFF
--- a/fabric-starter-client.js
+++ b/fabric-starter-client.js
@@ -460,7 +460,7 @@ class FabricStarterClient {
             proposal.targets = [this.peer];
         }
 
-        return util.retryOperation(cfg.INVOKE_RETRY_COUNT, async function () {
+//        return util.retryOperation(cfg.INVOKE_RETRY_COUNT, async function () {
             const txId = fsClient.client.newTransactionID(/*true*/);
 
             proposal.txId = txId;
@@ -490,7 +490,7 @@ class FabricStarterClient {
                 res.chaincodeResult = _.get(proposalResponse, "[0].response.payload");
                 return res;
             });
-        });
+//        });
     }
 
     errorCheck(results) {


### PR DESCRIPTION
Similar fix to https://github.com/olegabu/fabric-starter-rest/commit/800023d826220dd6d71fe43b7594ac44deb89858 , see https://github.com/olegabu/fabric-starter-rest/issues/81 . Why is ``util.retryOperation`` broken?