### PR TITLE
Whitelist channelId to prevent command injection

### DIFF
--- a/fabric-starter-client.js
+++ b/fabric-starter-client.js
@@ -179,6 +179,11 @@ class FabricStarterClient {
 
     async createChannel(channelId) {
         try {
+            // regex for whitelisting channelId
+            if (!/^[a-z][a-z0-9.-]*$/g.test(channelId)) {
+                throw new Error("channelId contains invalid characters.")
+            }
+            
             logger.info(`Creating channel ${channelId}`);
             // await fabricCLI.downloadOrdererMSP();
 
@@ -229,6 +234,11 @@ class FabricStarterClient {
     async addOrgToChannel(channelId, orgObj, certFiles) {
         await this.checkOrgDns(orgObj);
         try {
+            // regex for whitelisting channelId
+            if (!/^[a-z][a-z0-9.-]*$/g.test(channelId)) {
+                throw new Error("channelId contains invalid characters.")
+            }
+                        
             await util.checkRemotePort(cfg.addressFromTemplate(orgObj.peerName || 'peer0', orgObj.orgId, orgObj.domain), orgObj.peer0Port,
                 {from: `addOrgToChannel(${channelId}, ${orgObj})`}); //TODO: , throws: true
             let currentChannelConfigFile = await fabricCLI.fetchChannelConfig(channelId);


### PR DESCRIPTION
Only allow alphanumeric characters, `.`, and `-` for `channelId`.
Otherwise line 199 and line 244 is open to command injection attack.